### PR TITLE
add support for nested gen-binds in match patterns (sort of)

### DIFF
--- a/generic-bind/nested-binds-helper.rkt
+++ b/generic-bind/nested-binds-helper.rkt
@@ -1,0 +1,74 @@
+#lang racket/base
+
+(provide with-new-match-pat-def-set
+         splicing-with-new-match-pat-def-set
+         define-current-match-pat-def-set
+         (for-syntax make-gen-bind-match-expander-proc-maker
+                     ))
+
+(require racket/stxparam
+         racket/splicing
+         "syntax-parse-utils.rkt"
+         (for-syntax racket/base
+                     syntax/parse
+                     racket/set
+                     "stx-utils.rkt"
+                     ))
+
+(define-syntax-parameter current-match-pat-def-set #f)
+
+(begin-for-syntax
+  (define (get-current-match-pat-def-set)
+    (syntax-parameter-value #'current-match-pat-def-set))
+
+  (define (nested-gen-bind-not-supported-error stx)
+    (raise-syntax-error
+     #f
+     (string-append
+      "nested generic-binding instances not supported for Racket version "(version)"\n"
+      "  because syntax-local-match-introduce is needed")
+     stx))
+  
+  (define ((make-gen-bind-match-expander-proc-maker ~define-id))
+    ;; hash : (Hash-Table Any Symbol)
+    (define hash (make-hash))
+    (lambda (stx)
+      (define def-set (get-current-match-pat-def-set))
+      (cond [(set-mutable? def-set)
+             (unless syntax-local-match-introduce-available?
+               (nested-gen-bind-not-supported-error stx))
+             (define/syntax-parse name
+               (datum->stx stx (hash-ref! hash (syntax->datum+srcloc+props stx)
+                                 gensym)))
+             (define/syntax-parse -define ~define-id)
+             (define/syntax-parse stx* stx)
+             (define def
+               (syntax-local-match-introduce-2
+                (syntax/loc stx (-define stx* name))))
+             (set-add! def-set def)
+             #'name]
+            [else
+             (raise-syntax-error #f "not within a generic binding context" stx)]))))
+
+(define-syntax/parse with-new-match-pat-def-set #:stx stx
+  [(wnmpds expr:expr ...+)
+   (syntax/loc stx
+     (syntax-parameterize ([current-match-pat-def-set (mutable-set)])
+       expr ...))])
+
+(define-syntax/parse splicing-with-new-match-pat-def-set #:stx stx
+  [(swnmpds expr:expr ...+)
+   (syntax/loc stx
+     (splicing-syntax-parameterize ([current-match-pat-def-set (mutable-set)])
+       expr ...))])
+
+(define-syntax define-current-match-pat-def-set
+  (lambda (stx)
+    (define def-set (syntax-parameter-value #'current-match-pat-def-set))
+    (cond [(set-mutable? def-set)
+           (define/syntax-parse (def ...) (map syntax-local-introduce (set->list def-set)))
+           (begin0 #'(begin def ...)
+                   (set-clear! def-set))]
+          [else
+           (raise-syntax-error #f "no current-match-pat-def-set" stx)])))
+

--- a/generic-bind/stx-utils.rkt
+++ b/generic-bind/stx-utils.rkt
@@ -22,3 +22,65 @@
         [let-only ,let-only-prop]
         [names ,names-prop])
       body)]))
+
+(define (syntax-srcloc stx)
+  (srcloc (syntax-source stx)
+          (syntax-line stx)
+          (syntax-column stx)
+          (syntax-position stx)
+          (syntax-span stx)))
+
+(define (syntax-props stx)
+  (for/hash ([key (in-list (syntax-property-symbol-keys stx))])
+    (values key (syntax-property stx key))))
+
+(define (syntax->datum+srcloc+props stx)
+  (let ([stx.e  (syntax-e stx)]
+        [srcloc (syntax-srcloc stx)]
+        [keys   (syntax-property-symbol-keys stx)])
+    (list (stx->datum+srcloc+props stx.e)
+          (syntax-srcloc stx)
+          (syntax-props stx))))
+
+(define (stx->datum+srcloc+props x)
+  (match x
+    [(? syntax? stx) (syntax->datum+srcloc+props stx)]
+    [(? symbol? sym) sym]
+    [(? number? n) n]
+    [(? boolean? b) b]
+    [(? char? c) c]
+    [(? string? str) str]
+    [(? bytes? bs) bs]
+    [(? regexp? rx) rx]
+    [(box val) (box-immutable (stx->datum+srcloc+props val))]
+    ['() '()]
+    [(cons x.car x.cdr) (cons (stx->datum+srcloc+props x.car)
+                              (stx->datum+srcloc+props x.cdr))]
+    [(vector lst ...) (apply vector-immutable (map stx->datum+srcloc+props lst))]
+    [(? hash? hash)
+     (for/hash ([(key val) (in-hash hash)])
+       (values (stx->datum+srcloc+props key)
+               (stx->datum+srcloc+props val)))]
+    [(app prefab-struct-key (and key (not #f)))
+     (apply make-prefab-struct key
+            (map stx->datum+srcloc+props (rest (vector->list (struct->vector x)))))]
+    [_ x]))
+
+(define (datum->stx stx datum)
+  (datum->syntax stx datum stx stx))
+
+(define (syntax-local-match-introduce-fallback stx)
+  (error 'syntax-local-match-introduce
+         "not available in Racket version ~a"
+         (version)))
+
+(define syntax-local-match-introduce-2
+  (with-handlers ([exn:fail:filesystem:missing-module? (λ (e) syntax-local-match-introduce-fallback)])
+    (dynamic-require
+     'racket/match/syntax-local-match-introduce
+     'syntax-local-match-introduce
+     (λ () syntax-local-match-introduce-fallback))))
+
+(define syntax-local-match-introduce-available?
+  (not (eq? syntax-local-match-introduce-2 syntax-local-match-introduce-fallback)))
+


### PR DESCRIPTION
needs a version of racket (v6.1.0.5 or higher) that supports syntax-local-match-introduce
(one that includes https://github.com/plt/racket/commit/0b045ba77b3095f53a7f4e1deb5c82b9232e17f1)
although it doesn't break the other stuff if it doesn't