### PR TITLE
avoid nullable EH pattern

### DIFF
--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -611,7 +611,7 @@
       comb
       (~optional (~seq #:break? b?))
       (base ...) 
-      ((~seq sb:seq-binding ... wb:when-or-break ...) ...) body ...)
+      ((~and (~seq sb:seq-binding ... wb:when-or-break ...) (~seq _ ...+)) ...) body ...)
    #:with ((new-sb ...) ...)
    ;; append accounts for list added by splicing-syntax-class
    (map (λ (ss) (append-map 


### PR DESCRIPTION
This pattern should only match if there is at least one `seq-binding` or `when-or-break`.

(The old version of this pattern only worked because of a bug in syntax-parse. The bug will be removed soon and syntax-parse will raise a compile-time error if it detects a nullable EH pattern, or it will raise a run-time error on an empty EH pattern match.)
