### PR TITLE
Add for/fold #:result keyword

### DIFF
--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -663,18 +663,24 @@
 (mk~for/ hasheqv hash-set ((hasheqv)))
 
 (define-syntax/parse ~for/fold ; foldl
-  [(_ ([accum init] ...) (c:for-clause ...) bb:break/final-or-body ...)
+  [(_ ([accum init] ... (~optional (~seq #:result result)))
+      (c:for-clause ...)
+      bb:break/final-or-body ...)
    #:with (res ...) (generate-temporaries #'(accum ...))
    ;; combiner drops old accums and uses result(s) of body as current accums
    (template (~for/common
-              #:final values (λ (accum ... res ...) (values res ...))
+              #:final (?? (λ (accum ...) result) values)
+              (λ (accum ... res ...) (values res ...))
               ([accum init] ...) ((?@ . c) ...) (?@ . bb) ...))])
 (define-syntax/parse ~for*/fold
-  [(_ ([accum init] ...) (c:for-clause ...) bb:break/final-or-body ...)
+  [(_ ([accum init] ... (~optional (~seq #:result result)))
+      (c:for-clause ...)
+      bb:break/final-or-body ...)
    #:with (res ...) (generate-temporaries #'(accum ...))
    ;; combiner drops old accums and uses result(s) of body as current accums
    (template (~for*/common 
-              #:final values (λ (accum ... res ...) (values res ...))
+              #:final (?? (λ (accum ...) result) values)
+              (λ (accum ... res ...) (values res ...))
               ([accum init] ...) ((?@ . c) ...) (?@ . bb) ...))])
 
 (define-syntax/parse ~for/lists

--- a/generic-bind/generic-bind.scrbl
+++ b/generic-bind/generic-bind.scrbl
@@ -450,7 +450,7 @@ All the forms in this section are the same as their Racket counterparts (see @ra
 @defform[(~for/list ...)]{}
 @defform[(~for/lists ...)]{}
 @defform[(~for/vector ...)]{}
-@defform[(~for/fold ...)]{}
+@defform[(~for/fold ...)]{Allows generic binds in sequence clauses, not accumulator clauses.}
 @defform[(~for/first ...)]{}
 @defform[(~for/last ...)]{}
 @defform[(~for/or ...)]{}
@@ -465,7 +465,7 @@ All the forms in this section are the same as their Racket counterparts (see @ra
 @defform[(~for*/list ...)]{}
 @defform[(~for*/lists ...)]{}
 @defform[(~for*/vector ...)]{}
-@defform[(~for*/fold ...)]{}
+@defform[(~for*/fold ...)]{Allows generic binds in sequence clauses, not accumulator clauses.}
 @defform[(~for*/first ...)]{}
 @defform[(~for*/last ...)]{}
 @defform[(~for*/or ...)]{}


### PR DESCRIPTION
Related to https://github.com/stchang/generic-bind/issues/20#issuecomment-971077461, this adds support for the `#:result` keyword, and also clarifies that the generic binds are for the sequence-clauses in `for/fold`, not for the accumulator-clauses.