### PR TITLE
Add ~struct/contract

### DIFF
--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -39,7 +39,7 @@
          ~for* ~for*/list ~for*/fold ~for*/vector ~for*/lists 
          ~for*/first ~for*/last ~for*/and ~for*/or ~for*/sum ~for*/product  
          ~for*/hash ~for*/hasheq ~for*/hasheqv
-         define-match-bind ~struct)
+         define-match-bind ~struct ~struct/contract)
 
 ;; (define-generic-stx bind 
 ;;   (definer letter ids let-only nested-definers nested-idss))
@@ -232,6 +232,16 @@
   [(_ id:id super:id ... (field:struct-field ...) opt ...)
    #'(begin
        (struct id super ... (field ...) opt ...)
+       (define-match-bind (id field.name ...)))])
+
+(begin-for-syntax ;; ~struct/contract syntax classes
+  (define-syntax-class struct/contract-field
+    (pattern [field:struct-field contract:expr] #:attr name #'field.name))
+  ) ; end begin-for-syntax
+(define-syntax/parse ~struct/contract
+  [(_ id:id super:id ... (field:struct/contract-field ...) opt ...)
+   #'(begin
+       (struct/contract id super ... (field ...) opt ...)
        (define-match-bind (id field.name ...)))])
 
 

--- a/generic-bind/generic-bind.scrbl
+++ b/generic-bind/generic-bind.scrbl
@@ -611,7 +611,35 @@ keys
 vals
 ]}
 
-@defform[(~struct ...)]{Exactly like @racket[struct] except a new generic binding instance is also defined. Equivalent to using @racket[struct] and @racket[define-match-bind].
+@defform*[
+ [(~struct struct-id (field ...) struct-option ...)
+  (~struct struct-id super-struct-id (field ...) struct-option ...)]
+ #:grammar ([field field-id
+                   [field-id field-option ...]]
+            [struct-option #:mutable
+                           (code:line #:super super-expr)
+                           (code:line #:inspector inspector-expr)
+                           (code:line #:auto-value auto-expr)
+                           (code:line #:guard guard-expr)
+                           (code:line #:property prop-expr val-expr)
+                           (code:line #:transparent)
+                           (code:line #:prefab)
+                           (code:line #:sealed)
+                           (code:line #:authentic)
+                           (code:line #:name name-id)
+                           (code:line #:extra-name name-id)
+                           (code:line #:constructor-name constructor-id)
+                           (code:line #:extra-constructor-name constructor-id)
+                           (code:line #:reflection-name symbol-expr)
+                           (code:line #:methods gen:name-id method-defs)
+                           #:omit-define-syntaxes
+                           #:omit-define-values]
+            [field-option #:mutable
+                          #:auto]
+            [method-defs (definition ...)])]{
+Exactly like @racket[struct] except a new generic binding
+instance is also defined.
+Equivalent to using @racket[struct] and @racket[define-match-bind].
 
 
 @interaction[#:eval the-eval
@@ -635,7 +663,18 @@ Generic binding instance:
 ]}
 
 @do-if-struct/contract-available[
-@defform[(~struct/contract ...)]{
+@defform*[
+ [(~struct/contract struct-id (field ...) struct-option ...)
+  (~struct/contract struct-id super-struct-id (field ...) struct-option ...)]
+ #:grammar ([field field-id
+                   [field-id field-option ...]]
+            [struct-option #:mutable
+                           (code:line #:auto-value auto-expr)
+                           (code:line #:property prop-expr val-expr)
+                           (code:line #:transparent)
+                           #:omit-define-syntaxes]
+            [field-option #:mutable
+                          #:auto])]{
 Exactly like @racket[struct/contract] except a new generic
 binding instance is also defined.
 Equivalent to using @racket[struct/contract] and
@@ -660,7 +699,18 @@ Generic binding instance:
 (df d)
 ]}]
 
-@defform[(~define-struct/contract ...)]{
+@defform*[
+ [(~define-struct/contract struct-id (field ...) struct-option ...)
+  (~define-struct/contract (struct-id super-struct-id) (field ...) struct-option ...)]
+ #:grammar ([field field-id
+                   [field-id field-option ...]]
+            [struct-option #:mutable
+                           (code:line #:auto-value auto-expr)
+                           (code:line #:property prop-expr val-expr)
+                           (code:line #:transparent)
+                           #:omit-define-syntaxes]
+            [field-option #:mutable
+                          #:auto])]{
 Exactly like @racket[define-struct/contract] except a new
 generic binding instance is also defined.
 Equivalent to using @racket[define-struct/contract] and

--- a/generic-bind/generic-bind.scrbl
+++ b/generic-bind/generic-bind.scrbl
@@ -664,8 +664,12 @@ Generic binding instance:
 
 @do-if-struct/contract-available[
 @defform*[
- [(~struct/contract struct-id (field ...) struct-option ...)
-  (~struct/contract struct-id super-struct-id (field ...) struct-option ...)]
+ [(~struct/contract struct-id
+                    ([field contract-expr] ...)
+                    struct-option ...)
+  (~struct/contract struct-id super-struct-id
+                    ([field contract-expr] ...)
+                    struct-option ...)]
  #:grammar ([field field-id
                    [field-id field-option ...]]
             [struct-option #:mutable
@@ -700,8 +704,12 @@ Generic binding instance:
 ]}]
 
 @defform*[
- [(~define-struct/contract struct-id (field ...) struct-option ...)
-  (~define-struct/contract (struct-id super-struct-id) (field ...) struct-option ...)]
+ [(~define-struct/contract struct-id
+                           ([field contract-expr] ...)
+                           struct-option ...)
+  (~define-struct/contract (struct-id super-struct-id)
+                           ([field contract-expr] ...)
+                           struct-option ...)]
  #:grammar ([field field-id
                    [field-id field-option ...]]
             [struct-option #:mutable

--- a/generic-bind/generic-bind.scrbl
+++ b/generic-bind/generic-bind.scrbl
@@ -1,5 +1,6 @@
 #lang scribble/manual
 @(require scribble/eval
+          "version-utils.rkt"
           (for-label generic-bind racket syntax/parse))
 
 @title{Racket Generic Binding Forms}
@@ -631,4 +632,55 @@ Generic binding instance:
 @interaction[#:eval the-eval
 (~define (cf ($C e f g h)) (+ e f g h))
 (cf c); 44)
+]}
+
+@do-if-struct/contract-available[
+@defform[(~struct/contract ...)]{
+Exactly like @racket[struct/contract] except a new generic
+binding instance is also defined.
+Equivalent to using @racket[struct/contract] and
+@racket[define-match-bind].
+
+@interaction[#:eval the-eval
+(~struct/contract D ([a number?] [b string?] [[c #:mutable] list?]))
+]
+Behaves like a @racket[struct/contract]-defined struct:
+@interaction[#:eval the-eval
+(define d (D 200 "abcdefghij" '(k l m n o p)))
+(D? d)
+(D-a d)
+(D-b d)
+(D-c d)
+(set-D-c! d '(q r s))
+(D-c d)
+]
+Generic binding instance:
+@interaction[#:eval the-eval
+(~define (df ($D n s l)) (+ n (string-length s) (length l)))
+(df d)
+]}]
+
+@defform[(~define-struct/contract ...)]{
+Exactly like @racket[define-struct/contract] except a new
+generic binding instance is also defined.
+Equivalent to using @racket[define-struct/contract] and
+@racket[define-match-bind].
+
+@interaction[#:eval the-eval
+(~define-struct/contract E ([a number?] [b string?] [[c #:mutable] list?]))
+]
+Behaves like a @racket[define-struct/contract]-defined struct:
+@interaction[#:eval the-eval
+(define e (make-E 200 "abcdefghij" '(k l m n o p)))
+(E? e)
+(E-a e)
+(E-b e)
+(E-c e)
+(set-E-c! e '(q r s))
+(E-c e)
+]
+Generic binding instance:
+@interaction[#:eval the-eval
+(~define (ef ($E n s l)) (+ n (string-length s) (length l)))
+(ef e)
 ]}

--- a/generic-bind/stx-utils.rkt
+++ b/generic-bind/stx-utils.rkt
@@ -84,3 +84,9 @@
 (define syntax-local-match-introduce-available?
   (not (eq? syntax-local-match-introduce-2 syntax-local-match-introduce-fallback)))
 
+(define struct/contract-available?
+  (let-values ([(vars stxs)
+                (parameterize ([current-namespace (make-base-namespace)])
+                  (eval '(require racket/contract/region))
+                  (module->exports 'racket/contract/region))])
+    (ormap (λ (e) (eq? 'struct/contract (car e))) stxs)))

--- a/generic-bind/stx-utils.rkt
+++ b/generic-bind/stx-utils.rkt
@@ -89,4 +89,4 @@
                 (parameterize ([current-namespace (make-base-namespace)])
                   (eval '(require racket/contract/region))
                   (module->exports 'racket/contract/region))])
-    (ormap (λ (e) (eq? 'struct/contract (car e))) stxs)))
+    (ormap (λ (e) (eq? 'struct/contract (car e))) (cdr (assoc 0 stxs)))))

--- a/generic-bind/tests/generic-bind-tests.rkt
+++ b/generic-bind/tests/generic-bind-tests.rkt
@@ -751,7 +751,19 @@
   (check-equal? (C-c c) 7)
   (check-equal? (C-d c) 20)
   (check-equal? (cf c) 44)
-  
+
+  (~struct/contract D ([a number?] [b string?] [[c #:mutable] list?]))
+  (~define (df ($D n s l)) (+ n (string-length s) (length l)))
+  (define d (D 200 "abcdefghij" '(k l m n o p)))
+  (check-true (D? d))
+  (check-equal? (D-a d) 200)
+  (check-equal? (D-b d) "abcdefghij")
+  (check-equal? (D-c d) '(k l m n o p))
+  (check-equal? (df d) 216)
+  (set-D-c! d '(q r s))
+  (check-equal? (D-c d) '(q r s))
+  (check-equal? (df d) 213)
+
   ;; define-match-bind on just an id
   (define-match-bind hash-table)
   (~define ($hash-table [keys vals] ...) (hash 'a 1 'b 2 'c 3))

--- a/generic-bind/version-utils.rkt
+++ b/generic-bind/version-utils.rkt
@@ -1,0 +1,30 @@
+#lang racket/base
+
+(provide do-if-struct/contract-available
+         do-if-syntax-local-match-introduce-available
+         if-struct/contract-available-out)
+
+(require racket/provide-syntax
+         (for-syntax racket/base
+                     "stx-utils.rkt"))
+
+(define-syntax do-if-struct/contract-available
+  (lambda (stx)
+    (if struct/contract-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(begin stuff ...)])
+        #'(begin))))
+
+(define-syntax do-if-syntax-local-match-introduce-available
+  (lambda (stx)
+    (if syntax-local-match-introduce-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(begin stuff ...)])
+        #'(begin))))
+
+(define-provide-syntax if-struct/contract-available-out
+  (lambda (stx)
+    (if struct/contract-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(combine-out stuff ...)])
+        #'(combine-out))))


### PR DESCRIPTION

- [x] Documentation
- [x] Old racket versions that don't have `struct/contract`? One of: ~Version exceptions in the package source~, more of `do-if-struct/contract-available`?