### PR TITLE
Support for/foldr and for/hashalw, replace ~for/common with #:do clauses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["6.6", "6.11", "6.12", "7.3", "7.4", "8.4", "8.5", "stable", "current"]
+        racket-version: ["8.5", "8.9", "8.10", "stable", "current"]
     steps:
       - uses: actions/checkout@v2
       - uses: Bogdanp/setup-racket@v0.12

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.rkt~
-*.scrbl~
+*~
 compiled/
 doc/

--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ Experimenting with a generic bind form for Racket.
 
 [documentation](http://pkg-build.racket-lang.org/doc/generic-bind/index.html)
 
-Requires Racket 5.90.0.9 (for syntax/unsafe/for-transform).
+Requires Racket 8.4.0.2 or later, for the `#:do` keyword in for loops.
+
+For earlier Racket versions, use the [`up-to-v8.4`](https://github.com/stchang/generic-bind/tree/up-to-v8.4) branch.

--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -533,63 +533,44 @@
           #,@(for-clauses-do #'(rst ...)))]))
   ) ; begin-for-syntax for ~for forms
 
-(define-syntax/parse mk~for/
-  [(_ name)
-   #:with old-name (format-id #'name "for/~a" #'name)
-   #:with old-name* (format-id #'name "for*/~a" #'name)
-   #:with new-name (format-id #'name "~~for/~a" #'name)
-   #:with new-name* (format-id #'name "~~for*/~a" #'name)
-   #`(begin 
-       (define-syntax-parse-rule (new-name cs:for-clauses x (... ...)) 
-         (old-name cs.do x (... ...)))
-       (define-syntax-parse-rule (new-name* cs:for*-clauses x (... ...)) 
-         (old-name* cs.do x (... ...))))])
+(define-syntax/parse mk~for
+  [(_ name
+      (~optional hpat-before-clauses #:defaults ([hpat-before-clauses #'(~seq)])))
+   #:with old-name (format-id #'name "for~a" #'name)
+   #:with old-name* (format-id #'name "for*~a" #'name)
+   #:with new-name (format-id #'name "~~for~a" #'name)
+   #:with new-name* (format-id #'name "~~for*~a" #'name)
+   #`(begin
+       (define-syntax-parse-rule
+         (new-name (~and (~seq hpat-before-clauses) (~seq bcs (... ...)))
+                   cs:for-clauses
+                   x
+                   (... ...))
+         (old-name bcs (... ...) cs.do x (... ...)))
+       (define-syntax-parse-rule
+         (new-name* (~and (~seq hpat-before-clauses) (~seq bcs (... ...)))
+                    cs:for*-clauses
+                    x
+                    (... ...))
+         (old-name* bcs (... ...) cs.do x (... ...))))])
 
-(define-syntax-parse-rule (~for cs:for-clauses x ...) (for cs.do x ...))
-(define-syntax-parse-rule (~for* cs:for*-clauses x ...) (for* cs.do x ...))
+(mk~for ||)
+(mk~for /list)
+(mk~for /first)
+(mk~for /last)
+(mk~for /and)
+(mk~for /or)
+(mk~for /sum)
+(mk~for /product)
+(mk~for /hash)
+(mk~for /hasheq)
+(mk~for /hasheqv)
 
-(mk~for/ list)
-(mk~for/ first)
-(mk~for/ last)
-(mk~for/ and)
-(mk~for/ or)
-(mk~for/ sum)
-(mk~for/ product)
-(mk~for/ hash)
-(mk~for/ hasheq)
-(mk~for/ hasheqv)
+(mk~for /fold accums)
 
-(define-syntax-parse-rule (~for/fold accums cs:for-clauses bb ...)
-  (for/fold accums cs.do bb ...))
-(define-syntax-parse-rule (~for*/fold accums cs:for*-clauses bb ...)
-  (for*/fold accums cs.do bb ...))
+(mk~for /foldr accums)
 
-(define-syntax-parse-rule (~for/foldr accums cs:for-clauses bb ...)
-  (for/foldr accums cs.do bb ...))
-(define-syntax-parse-rule (~for*/foldr accums cs:for*-clauses bb ...)
-  (for*/foldr accums cs.do bb ...))
+(mk~for /lists accums)
 
-(define-syntax-parse-rule (~for/lists accums cs:for-clauses bb ...)
-  (for/lists accums cs.do bb ...))
-(define-syntax-parse-rule (~for*/lists accums cs:for*-clauses bb ...)
-  (for*/lists accums cs.do bb ...))
-
-(define-syntax-parse-rule
-  (~for/vector (~optional (~seq (~seq #:length len) (~optional (~seq #:fill fill))))
-               cs:for-clauses
-               bb
-               ...)
-  (for/vector (~? (~@ (~@ #:length len) (~? (~@ #:fill fill))))
-    cs.do
-    bb
-    ...))
-(define-syntax-parse-rule
-  (~for*/vector (~optional (~seq (~seq #:length len) (~optional (~seq #:fill fill))))
-                cs:for*-clauses
-                bb
-                ...)
-  (for*/vector (~? (~@ (~@ #:length len) (~? (~@ #:fill fill))))
-    cs.do
-    bb
-    ...))
-
+(mk~for /vector
+        (~optional (~seq (~seq #:length len) (~optional (~seq #:fill fill)))))

--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -37,10 +37,10 @@
          ~for ~for/list ~for/vector ~for/fold ~for/foldr ~for/lists
          ~for/first ~for/last
          ~for/and ~for/or ~for/sum ~for/product 
-         ~for/hash ~for/hasheq ~for/hasheqv
+         ~for/hash ~for/hasheq ~for/hasheqv ~for/hashalw
          ~for* ~for*/list ~for*/fold ~for*/foldr ~for*/vector ~for*/lists 
          ~for*/first ~for*/last ~for*/and ~for*/or ~for*/sum ~for*/product  
-         ~for*/hash ~for*/hasheq ~for*/hasheqv
+         ~for*/hash ~for*/hasheq ~for*/hasheqv ~for*/hashalw
          define-match-bind ~struct ~define-struct/contract
          (if-struct/contract-available-out ~struct/contract))
 
@@ -565,6 +565,7 @@
 (mk~for /hash)
 (mk~for /hasheq)
 (mk~for /hasheqv)
+(mk~for /hashalw)
 
 (mk~for /fold accums)
 

--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -34,10 +34,11 @@
                      [~m $] [~vs ⋈]
                      [~case-lambda ~case-lam] [~case-define ~case-def])
          ~let ~let* ~letrec
-         ~for ~for/list ~for/vector ~for/fold ~for/lists ~for/first ~for/last 
+         ~for ~for/list ~for/vector ~for/fold ~for/foldr ~for/lists
+         ~for/first ~for/last
          ~for/and ~for/or ~for/sum ~for/product 
          ~for/hash ~for/hasheq ~for/hasheqv
-         ~for* ~for*/list ~for*/fold ~for*/vector ~for*/lists 
+         ~for* ~for*/list ~for*/fold ~for*/foldr ~for*/vector ~for*/lists 
          ~for*/first ~for*/last ~for*/and ~for*/or ~for*/sum ~for*/product  
          ~for*/hash ~for*/hasheq ~for*/hasheqv
          define-match-bind ~struct ~define-struct/contract
@@ -562,6 +563,11 @@
   (for/fold accums cs.do bb ...))
 (define-syntax-parse-rule (~for*/fold accums cs:for*-clauses bb ...)
   (for*/fold accums cs.do bb ...))
+
+(define-syntax-parse-rule (~for/foldr accums cs:for-clauses bb ...)
+  (for/foldr accums cs.do bb ...))
+(define-syntax-parse-rule (~for*/foldr accums cs:for*-clauses bb ...)
+  (for*/foldr accums cs.do bb ...))
 
 (define-syntax-parse-rule (~for/lists accums cs:for-clauses bb ...)
   (for/lists accums cs.do bb ...))

--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -34,15 +34,17 @@
                      [~m $] [~vs ⋈]
                      [~case-lambda ~case-lam] [~case-define ~case-def])
          ~let ~let* ~letrec
-         ~for ~for/list ~for/vector ~for/fold ~for/foldr ~for/lists
+         ~for ~for/list ~for/vector ~for/fold ~for/lists
          ~for/first ~for/last
          ~for/and ~for/or ~for/sum ~for/product 
-         ~for/hash ~for/hasheq ~for/hasheqv ~for/hashalw
-         ~for* ~for*/list ~for*/fold ~for*/foldr ~for*/vector ~for*/lists 
+         ~for/hash ~for/hasheq ~for/hasheqv
+         ~for* ~for*/list ~for*/fold ~for*/vector ~for*/lists 
          ~for*/first ~for*/last ~for*/and ~for*/or ~for*/sum ~for*/product  
-         ~for*/hash ~for*/hasheq ~for*/hasheqv ~for*/hashalw
+         ~for*/hash ~for*/hasheq ~for*/hasheqv
          define-match-bind ~struct ~define-struct/contract
-         (if-struct/contract-available-out ~struct/contract))
+         (if-struct/contract-available-out ~struct/contract)
+         (if-for/foldr-available-out ~for/foldr ~for*/foldr)
+         (if-for/hashalw-available-out ~for/hashalw ~for*/hashalw))
 
 ;; (define-generic-stx bind 
 ;;   (definer letter ids let-only nested-definers nested-idss))
@@ -565,11 +567,13 @@
 (mk~for /hash)
 (mk~for /hasheq)
 (mk~for /hasheqv)
-(mk~for /hashalw)
+(do-if-for/hashalw-available
+ (mk~for /hashalw))
 
 (mk~for /fold accums)
 
-(mk~for /foldr accums)
+(do-if-for/foldr-available
+ (mk~for /foldr accums))
 
 (mk~for /lists accums)
 

--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -513,6 +513,16 @@
   (define-splicing-syntax-class break/final-or-body 
     (pattern :break-or-final) (pattern body:expr))
 
+  (define-syntax-class for-clauses
+    #:attributes (do)
+    (pattern (c:for-clause ...)
+      #:with do (for-clauses-do #'(c ...))))
+  (define-syntax-class for*-clauses
+    #:attributes (do)
+    (pattern (c:for-clause ...)
+      #:with do
+      (append-map (λ (c) (syntax->list (for-clauses-do (list c))))
+                  (attribute c))))
   (define (for-clauses-do cs)
     (syntax-parse cs
       [() #'()]
@@ -522,258 +532,58 @@
           #,@(for-clauses-do #'(rst ...)))]))
   ) ; begin-for-syntax for ~for forms
 
-(define-syntax/parse ~for/common ; essentially a foldl (ie uses an accum(s))
-  ;; this clause allows naming of the accums so the body can reference them
-  ;; -- used by for/fold and for/lists
-  [(_ (~optional (~seq #:final final))
-      combiner
-      (~optional (~seq #:break? break?))
-      ([accum base] ...)
-      (c:for-clause ...) bb:break/final-or-body ...)
-   #:with (body-res ...) (generate-temporaries #'(accum ...))
-   #:with (c-do ...) (for-clauses-do #'(c ...))
-   #:with (b ...) (template ((?@ . bb) ...))
-   #:with ((pre ...) (body ...)) (split-for-body #'(b ...) #'(b ...))
-   #:with (pre-body:break/final-or-body ...) #'(pre ...)
-   #:with do-body
-   ;; this must be a call-with-values because the number of results
-   ;; is unpredictable (may be 0 values or multiple values)
-   #`(call-with-values 
-      (lambda () body ...)
-      (lambda results (apply combiner accum ... results)))
-   #:with expanded-for
-   #`(for/fold ([accum base] ...) (c-do ...)
-       (~? (~@ #:break (break? accum ...)))
-       (~@ . pre-body)
-       ...
-       do-body)
-   (if (attribute final)
-       #'(let-values ([(accum ...) expanded-for]) (final accum ...))
-       #'expanded-for)]
-  ;; this clause has unnamed accums; name them and then call the first clause
-  [(_ (~optional (~seq #:final final))
-      combiner
-      (~optional (~seq #:break? break?))
-      (base ...) 
-      (c:for-clause ...) bb:break/final-or-body ...)
-   #:with (accum ...) (generate-temporaries #'(base ...))
-   #`(~for/common #,@(if (attribute final) #'(#:final final) #'())
-                  combiner 
-                  #,@(if (attribute break?) #'(#:break? break?) #'())
-                  ([accum base] ...) 
-                  #,@(template (((?@ . c) ...) (?@ . bb) ...)))])
-
-;; inserts #:when #t between each (non-#:when/unless) clause
-(define-syntax/parse ~for*/common
-  [(_ (~optional (~seq #:final fin))
-      comb
-      (~optional (~seq #:break? b?))
-      (base ...) 
-      ((~and (~seq sb:seq-binding ... wb:when-or-break ...) (~seq _ ...+)) ...) body ...)
-   #:with ((new-sb ...) ...)
-   ;; append accounts for list added by splicing-syntax-class
-   (map (λ (ss) (append-map 
-                 (λ (s) (append (syntax->list s) (list #'#:when #'#t)))
-                 (syntax->list ss)))
-        (syntax->list #'((sb ...) ...)))
-   ;; wb is also a list (due to splicing-stx-class)
-   #:with (new-clause ...) 
-   (template ((?@ . (new-sb ... (?@ . ((?@ . wb) ...)))) ...))
-   #`(~for/common #,@(if (attribute fin) #'(#:final fin) #'())
-                  comb 
-                  #,@(if (attribute b?) #'(#:break? b?) #'())
-                  (base ...) (new-clause ...) body ...)])
-
 (define-syntax/parse mk~for/
-  [(_ name combiner (base ...)
-      (~optional (~seq #:final fin))
-      (~optional (~seq #:break? b?)))
+  [(_ name)
+   #:with old-name (format-id #'name "for/~a" #'name)
+   #:with old-name* (format-id #'name "for*/~a" #'name)
    #:with new-name (format-id #'name "~~for/~a" #'name)
    #:with new-name* (format-id #'name "~~for*/~a" #'name)
    #`(begin 
-       (define-syntax-rule (new-name x (... ...)) 
-         (~for/common #,@(if (attribute fin) #'(#:final fin) #'())
-                      combiner 
-                      #,@(if (attribute b?) #'(#:break? b?) #'())
-                      (base ...) x (... ...)))
-       (define-syntax-rule (new-name* x (... ...)) 
-         (~for*/common #,@(if (attribute fin) #'(#:final fin) #'()) 
-                       combiner 
-                       #,@(if (attribute b?) #'(#:break? b?) #'())
-                       (base ...) x (... ...))))])
+       (define-syntax-parse-rule (new-name cs:for-clauses x (... ...)) 
+         (old-name cs.do x (... ...)))
+       (define-syntax-parse-rule (new-name* cs:for*-clauses x (... ...)) 
+         (old-name* cs.do x (... ...))))])
 
-(define-syntax-rule (~for x ...) (~for/common void ((void)) x ...))
-(define-syntax-rule (~for* x ...) (~for*/common void ((void)) x ...))
+(define-syntax-parse-rule (~for cs:for-clauses x ...) (for cs.do x ...))
+(define-syntax-parse-rule (~for* cs:for*-clauses x ...) (for* cs.do x ...))
 
-;; ~for/list ~for*/list and ~for/lists probably need a "right folding" for/common
-;;   but for now, just reverse the output
-;; - have to reverse args in cons bc acc is first
-(mk~for/ list (λ (acc y) (unsafe-cons-list y acc)) (null) #:final reverse)
-;; break as soon as we find something
-(mk~for/ first (λ (acc y) y) (#f) #:break? identity)
-(mk~for/ last (λ (acc y) y) (#f))
-(mk~for/ and (λ (acc y) (and acc y)) (#t) #:break? not)
-(mk~for/ or (λ (acc y) (or acc y)) (#f) #:break? identity)
-(mk~for/ sum + (0))
-(mk~for/ product * (1))
-(mk~for/ hash hash-set ((hash)))
-(mk~for/ hasheq hash-set ((hasheq)))
-(mk~for/ hasheqv hash-set ((hasheqv)))
+(mk~for/ list)
+(mk~for/ first)
+(mk~for/ last)
+(mk~for/ and)
+(mk~for/ or)
+(mk~for/ sum)
+(mk~for/ product)
+(mk~for/ hash)
+(mk~for/ hasheq)
+(mk~for/ hasheqv)
 
-(define-syntax/parse ~for/fold ; foldl
-  [(_ ([accum init] ... (~optional (~seq #:result result)))
-      (c:for-clause ...)
-      bb:break/final-or-body ...)
-   #:with (res ...) (generate-temporaries #'(accum ...))
-   ;; combiner drops old accums and uses result(s) of body as current accums
-   (template (~for/common
-              #:final (?? (λ (accum ...) result) values)
-              (λ (accum ... res ...) (values res ...))
-              ([accum init] ...) ((?@ . c) ...) (?@ . bb) ...))])
-(define-syntax/parse ~for*/fold
-  [(_ ([accum init] ... (~optional (~seq #:result result)))
-      (c:for-clause ...)
-      bb:break/final-or-body ...)
-   #:with (res ...) (generate-temporaries #'(accum ...))
-   ;; combiner drops old accums and uses result(s) of body as current accums
-   (template (~for*/common 
-              #:final (?? (λ (accum ...) result) values)
-              (λ (accum ... res ...) (values res ...))
-              ([accum init] ...) ((?@ . c) ...) (?@ . bb) ...))])
+(define-syntax-parse-rule (~for/fold accums cs:for-clauses bb ...)
+  (for/fold accums cs.do bb ...))
+(define-syntax-parse-rule (~for*/fold accums cs:for*-clauses bb ...)
+  (for*/fold accums cs.do bb ...))
 
-(define-syntax/parse ~for/lists
-  [(_ (accum ...) (c:for-clause ...) bb:break/final-or-body ...)
-   #:with (res ...) (generate-temporaries #'(accum ...))
-   ;; combiner drops old accums and uses result(s) of body as current accums
-   (template (~for/common 
-              #:final (λ (accum ...) (values (reverse accum) ...))
-              (λ (accum ... res ...) (values (unsafe-cons-list res accum) ...))
-              ([accum null] ...) ((?@ . c) ...) (?@ . bb) ...))])
+(define-syntax-parse-rule (~for/lists accums cs:for-clauses bb ...)
+  (for/lists accums cs.do bb ...))
+(define-syntax-parse-rule (~for*/lists accums cs:for*-clauses bb ...)
+  (for*/lists accums cs.do bb ...))
 
-(define-syntax/parse ~for*/lists
-  [(_ (accum ...) (c:for-clause ...) bb:break/final-or-body ...)
-   #:with (res ...) (generate-temporaries #'(accum ...))
-   ;; combiner drops old accums and uses result(s) of body as current accums
-   (template (~for*/common 
-              #:final (λ (accum ...) (values (reverse accum) ...))
-              (λ (accum ... res ...) (values (unsafe-cons-list res accum) ...))
-              ([accum null] ...) ((?@ . c) ...) (?@ . bb) ...))])
+(define-syntax-parse-rule
+  (~for/vector (~optional (~seq (~seq #:length len) (~optional (~seq #:fill fill))))
+               cs:for-clauses
+               bb
+               ...)
+  (for/vector (~? (~@ (~@ #:length len) (~? (~@ #:fill fill))))
+    cs.do
+    bb
+    ...))
+(define-syntax-parse-rule
+  (~for*/vector (~optional (~seq (~seq #:length len) (~optional (~seq #:fill fill))))
+                cs:for*-clauses
+                bb
+                ...)
+  (for*/vector (~? (~@ (~@ #:length len) (~? (~@ #:fill fill))))
+    cs.do
+    bb
+    ...))
 
-;; ~for/vector is an imperative mess
-(define-syntax/parse ~for/vector
-  [(_ (~optional (~seq (~seq #:length len) 
-                       (~optional (~seq #:fill fill) #:defaults ([fill #'0]))))
-      x ...)
-   (if (attribute len)
-       ;; if #:length is specified, then we need a break? because there may
-       ;; be more iterations than #:length
-       #'(let ([vec (make-vector len fill)]
-               [vec-len len])
-           (define i 0)
-           (~for/common 
-            #:final (λ _ vec)
-            (λ (acc y) (unsafe-vector-set! vec i y) (set! i (add1 i))) ; combiner
-            #:break? (λ _ (>= i vec-len))
-            ((void)) ; base ...
-            x ...))
-       ;; repeatedly checking break? is slow so if no #:length is given,
-       ;; first build list and then copy into a result vector
-       #'(~for/common
-          #:final 
-          (λ (lst) 
-            (let* ([vec-len (length lst)]
-                   [vec (make-vector vec-len)])
-              (let loop ([n vec-len] [lst lst])
-                (if (zero? n) vec
-                    (let ([n-1 (sub1 n)])
-                      (unsafe-vector-set! vec n-1 (unsafe-car lst))
-                      (loop n-1 (unsafe-cdr lst)))))))
-          (λ (acc y) (unsafe-cons-list y acc))
-          (null)
-          x ...))])
-(define-syntax/parse ~for*/vector
-  [(_ (~optional (~seq (~seq #:length len) 
-                       (~optional (~seq #:fill fill) #:defaults ([fill #'0]))))
-      x ...)
-   (if (attribute len)
-       ;; if #:length is specified, then we need a break? because there may
-       ;; be more iterations than #:length
-       #'(let ([vec (make-vector len fill)]
-               [vec-len len])
-           (define i 0)
-           (~for*/common 
-            #:final (λ _ vec)
-            (λ (acc y) (unsafe-vector-set! vec i y) (set! i (add1 i))) ; combiner
-            #:break? (λ _ (>= i vec-len))
-            ((void)) ; base ...
-            x ...))
-       ;; repeatedly checking break? is slow so if no #:length is given,
-       ;; first build list and then copy into a result vector
-       #'(~for*/common
-          #:final 
-          (λ (lst) 
-            (let* ([vec-len (length lst)]
-                   [vec (make-vector vec-len)])
-              (let loop ([n vec-len] [lst lst])
-                (if (zero? n) vec
-                    (let ([n-1 (sub1 n)])
-                      (unsafe-vector-set! vec n-1 (unsafe-car lst))
-                      (loop n-1 (unsafe-cdr lst)))))))
-          (λ (acc y) (unsafe-cons-list y acc))
-          (null)
-          x ...))])
-
-
-;; this is a right-folding ~for/common
-;;  it's currently unused, but would probably be faster for ~for/list
-;#;(define-syntax (~for/common/foldr stx)
-;  (syntax-parse stx
-;    [(_ flatten combiner base (c:for-clause ...) bb:break-clause ... body:expr ...)
-;     #:with expanded-for
-;     (let ([depth 0])
-;       (define res
-;     (let stxloop ([cs #'(c ... bb ...)])
-;       (syntax-parse cs
-;         [() #'(begin body ...)]
-;         [(([b:for-binder seq:expr]) ... (w:when-or-break) ... rst ...)
-;;          #:with (s ...) (generate-temporaries #'(b ...))
-;          #:with (seq-not-empty? ...) (generate-temporaries #'(b ...))
-;          #:with (seq-next ...) (generate-temporaries #'(b ...))
-;          #:with new-loop (generate-temporary)
-;          #:with skip-it #'(new-loop) ;;#'(new-loop (seq-rst s) ...)
-;          #:with do-it 
-;;            #`(call-with-values 
-;;               (λ () #,(stxloop #'(rst ...)))
-;;               (λ this-iter (call-with-values 
-;;                        (λ () skip-it)
-;;                        (λ other-iters (combiner this-iter other-iters)))))
-;          #`(let ([result #,(stxloop #'(rst ...))]) (combiner result skip-it))
-;          #:with its-done #'base
-;          #:with one-more-time 
-;;            #`(call-with-values 
-;;               (λ () #,(stxloop #'(rst ...)))
-;;               (λ this-iter (call-with-values 
-;;                             (λ () base)
-;;                             (λ other-iters (combiner this-iter other-iters)))))
-;            #`(let ([result #,(stxloop #'(rst ...))]) (combiner result base))
-;          #:with conditional-body
-;            (let whenloop ([ws (syntax->list #'((w) ...))])
-;              (if (null? ws)
-;                  #'do-it
-;                  (syntax-parse (car ws)
-;                    [((#:when guard)) #`(if guard #,(whenloop (cdr ws)) skip-it)]
-;                    [((#:unless guard)) #`(if guard skip-it #,(whenloop (cdr ws)))]
-;                    [((#:break guard)) #`(if guard its-done #,(whenloop (cdr ws)))]
-;                    [((#:final guard)) #`(if guard one-more-time #,(whenloop (cdr ws)))])))
-;            (set! depth (add1 depth))
-;          #`(let-values ([(seq-not-empty? seq-next) (sequence-generate seq)] ...)
-;               (let new-loop ()
-;                 (if (and (seq-not-empty?) ...)
-;                     (~let ([b.new-b (seq-next)] ...)
-;;                       #,@(append-map syntax->list (syntax->list #'(b.nested-defs ...)))
-;                           conditional-body)
-;                     base)))])))
-;       (let flatten-loop ([n (- depth 2)] [res res])
-;         (if (<= n 0) res
-;           (flatten-loop (sub1 n) #`(flatten #,res)))))
-;     #'expanded-for]))

--- a/generic-bind/generic-bind.rkt
+++ b/generic-bind/generic-bind.rkt
@@ -542,7 +542,11 @@
       (lambda () body ...)
       (lambda results (apply combiner accum ... results)))
    #:with expanded-for
-   #`(for/fold ([accum base] ...) (c-do ...) (~@ . pre-body) ... do-body)
+   #`(for/fold ([accum base] ...) (c-do ...)
+       (~? (~@ #:break (break? accum ...)))
+       (~@ . pre-body)
+       ...
+       do-body)
    (if (attribute final)
        #'(let-values ([(accum ...) expanded-for]) (final accum ...))
        #'expanded-for)]

--- a/generic-bind/generic-bind.scrbl
+++ b/generic-bind/generic-bind.scrbl
@@ -452,6 +452,9 @@ All the forms in this section are the same as their Racket counterparts (see @ra
 @defform[(~for/lists ...)]{}
 @defform[(~for/vector ...)]{}
 @defform[(~for/fold ...)]{Allows generic binds in sequence clauses, not accumulator clauses.}
+@do-if-for/foldr-available[
+ @defform[(~for/foldr ...)]{Allows generic binds in sequence clauses, not accumulator clauses.}]
+
 @defform[(~for/first ...)]{}
 @defform[(~for/last ...)]{}
 @defform[(~for/or ...)]{}
@@ -461,12 +464,17 @@ All the forms in this section are the same as their Racket counterparts (see @ra
 @defform[(~for/hash ...)]{}
 @defform[(~for/hasheq ...)]{}
 @defform[(~for/hasheqv ...)]{}
+@do-if-for/hashalw-available[
+ @defform[(~for/hashalw ...)]{}]
 
 @defform[(~for* ...)]{}
 @defform[(~for*/list ...)]{}
 @defform[(~for*/lists ...)]{}
 @defform[(~for*/vector ...)]{}
 @defform[(~for*/fold ...)]{Allows generic binds in sequence clauses, not accumulator clauses.}
+@do-if-for/foldr-available[
+ @defform[(~for*/foldr ...)]{Allows generic binds in sequence clauses, not accumulator clauses.}]
+
 @defform[(~for*/first ...)]{}
 @defform[(~for*/last ...)]{}
 @defform[(~for*/or ...)]{}
@@ -476,6 +484,8 @@ All the forms in this section are the same as their Racket counterparts (see @ra
 @defform[(~for*/hash ...)]{}
 @defform[(~for*/hasheq ...)]{}
 @defform[(~for*/hasheqv ...)]{}
+@do-if-for/hashalw-available[
+ @defform[(~for*/hashalw ...)]{}]
 
 @examples[#:eval the-eval
 (~for/list ([($ (list x y)) '((1 2) (3 4) (5 6))]) (list y x));

--- a/generic-bind/stx-utils.rkt
+++ b/generic-bind/stx-utils.rkt
@@ -84,9 +84,18 @@
 (define syntax-local-match-introduce-available?
   (not (eq? syntax-local-match-introduce-2 syntax-local-match-introduce-fallback)))
 
-(define struct/contract-available?
+(define (module-export-available? mod sym)
   (let-values ([(vars stxs)
                 (parameterize ([current-namespace (make-base-namespace)])
-                  (eval '(require racket/contract/region))
-                  (module->exports 'racket/contract/region))])
-    (ormap (λ (e) (eq? 'struct/contract (car e))) (cdr (assoc 0 stxs)))))
+                  (eval `(require ,mod))
+                  (module->exports mod))])
+    (ormap (λ (e) (eq? sym (car e))) (cdr (assoc 0 stxs)))))
+
+(define struct/contract-available?
+  (module-export-available? 'racket/contract/region 'struct/contract))
+
+(define for/foldr-available?
+  (module-export-available? 'racket/base 'for/foldr))
+
+(define for/hashalw-available?
+  (module-export-available? 'racket/base 'for/hashalw))

--- a/generic-bind/tests/for-tests/for.rktl
+++ b/generic-bind/tests/for-tests/for.rktl
@@ -377,11 +377,11 @@
                 (values v v)))
 
 (do-if-for/hashalw-available
- (test #hashalw((a . 1) (b . 2) (c . 3)) 'mk-hashalw
+ (test (hashalw 'a 1 'b 2 'c 3) 'mk-hashalw
        (for/hashalw ([v (in-naturals)]
                      [k '(a b c)])
          (values k (add1 v))))
- (test #hashalw((a . 3) (b . 3) (c . 3)) 'mk-hashalw
+ (test (hashalw 'a 3 'b 3 'c 3) 'mk-hashalw
        (for*/hashalw ([k '(a b c)]
                       [v (in-range 3)])
          (values k (add1 v)))))

--- a/generic-bind/tests/for-tests/for.rktl
+++ b/generic-bind/tests/for-tests/for.rktl
@@ -350,6 +350,10 @@
       (for/hash ([v (in-naturals)]
                  [k '(a b c)])
                 (values k (add1 v))))
+(test #hashalw((a . 1) (b . 2) (c . 3)) 'mk-hashalw
+      (for/hashalw ([v (in-naturals)]
+                    [k '(a b c)])
+        (values k (add1 v))))
 (test #hasheq((a . 1) (b . 2) (c . 3)) 'mk-hasheq
       (for/hasheq ([v (in-naturals)]
                    [k '(a b c)])
@@ -358,6 +362,10 @@
       (for*/hash ([k '(a b c)]
                    [v (in-range 3)])
                   (values k (add1 v))))
+(test #hashalw((a . 3) (b . 3) (c . 3)) 'mk-hashalw
+      (for*/hashalw ([k '(a b c)]
+                     [v (in-range 3)])
+        (values k (add1 v))))
 (test #hasheq((a . 3) (b . 3) (c . 3)) 'mk-hasheq
       (for*/hasheq ([k '(a b c)]
                      [v (in-range 3)])

--- a/generic-bind/tests/for-tests/for.rktl
+++ b/generic-bind/tests/for-tests/for.rktl
@@ -495,3 +495,58 @@
      (check-false evaluated-yet?)
      (force start)
      (check-true evaluated-yet?))))
+
+(test-case "for vs for* scope"
+  (let ([a '(o0o uwu tτt eϵe rρr ....)]
+        [b '(#\s #\p #\a #\c #\e #\!)]
+        [c 3])
+    (check-equal? (for/list ([($ (app symbol->string b)) a]
+                             [($ (app char-upcase c)) b])
+                    (list b c))
+                  '(("o0o" #\S)
+                    ("uwu" #\P)
+                    ("tτt" #\A)
+                    ("eϵe" #\C)
+                    ("rρr" #\E)
+                    ("...." #\!)))
+    (check-equal? (for/list ([($ (app symbol->string b)) a]
+                             #:when (= c (string-length b))
+                             [($ (app char-upcase c)) b])
+                    (list b c))
+                  '(("o0o" #\O)
+                    ("o0o" #\0)
+                    ("o0o" #\O)
+                    ("uwu" #\U)
+                    ("uwu" #\W)
+                    ("uwu" #\U)
+                    ("tτt" #\T)
+                    ("tτt" #\Τ) ; Greek uppercase Tau
+                    ("tτt" #\T)
+                    ("eϵe" #\E)
+                    ("eϵe" #\Ε) ; Greek uppercase Epsilon
+                    ("eϵe" #\E)
+                    ("rρr" #\R)
+                    ("rρr" #\Ρ) ; Greek uppercase Rho
+                    ("rρr" #\R)))
+    (check-equal? (for*/list ([($ (app symbol->string b)) a]
+                              [($ (app char-upcase c)) b])
+                    (list b c))
+                  '(("o0o" #\O)
+                    ("o0o" #\0)
+                    ("o0o" #\O)
+                    ("uwu" #\U)
+                    ("uwu" #\W)
+                    ("uwu" #\U)
+                    ("tτt" #\T)
+                    ("tτt" #\Τ) ; Greek uppercase Tau
+                    ("tτt" #\T)
+                    ("eϵe" #\E)
+                    ("eϵe" #\Ε) ; Greek uppercase Epsilon
+                    ("eϵe" #\E)
+                    ("rρr" #\R)
+                    ("rρr" #\Ρ) ; Greek uppercase Rho
+                    ("rρr" #\R)
+                    ("...." #\.)
+                    ("...." #\.)
+                    ("...." #\.)
+                    ("...." #\.)))))

--- a/generic-bind/version-utils.rkt
+++ b/generic-bind/version-utils.rkt
@@ -2,7 +2,11 @@
 
 (provide do-if-struct/contract-available
          do-if-syntax-local-match-introduce-available
-         if-struct/contract-available-out)
+         do-if-for/foldr-available
+         do-if-for/hashalw-available
+         if-struct/contract-available-out
+         if-for/foldr-available-out
+         if-for/hashalw-available-out)
 
 (require racket/provide-syntax
          (for-syntax racket/base
@@ -22,9 +26,37 @@
           [(_ stuff ...) #'(begin stuff ...)])
         #'(begin))))
 
+(define-syntax do-if-for/foldr-available
+  (lambda (stx)
+    (if for/hashalw-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(begin stuff ...)])
+        #'(begin))))
+
+(define-syntax do-if-for/hashalw-available
+  (lambda (stx)
+    (if for/hashalw-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(begin stuff ...)])
+        #'(begin))))
+
 (define-provide-syntax if-struct/contract-available-out
   (lambda (stx)
     (if struct/contract-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(combine-out stuff ...)])
+        #'(combine-out))))
+
+(define-provide-syntax if-for/foldr-available-out
+  (lambda (stx)
+    (if for/foldr-available?
+        (syntax-case stx ()
+          [(_ stuff ...) #'(combine-out stuff ...)])
+        #'(combine-out))))
+
+(define-provide-syntax if-for/hashalw-available-out
+  (lambda (stx)
+    (if for/hashalw-available?
         (syntax-case stx ()
           [(_ stuff ...) #'(combine-out stuff ...)])
         #'(combine-out))))

--- a/generic-bind/version-utils.rkt
+++ b/generic-bind/version-utils.rkt
@@ -28,7 +28,7 @@
 
 (define-syntax do-if-for/foldr-available
   (lambda (stx)
-    (if for/hashalw-available?
+    (if for/foldr-available?
         (syntax-case stx ()
           [(_ stuff ...) #'(begin stuff ...)])
         #'(begin))))

--- a/info.rkt
+++ b/info.rkt
@@ -3,5 +3,5 @@
 ;; technically, I should revert to #lang setup/infotab
 ;; and declare the dependency on racket, not base
 ;; see: https://www.mail-archive.com/users@racket-lang.org/msg23164.html
-(define deps '(("base" #:version "5.90.0.9")))
+(define deps '(("base" #:version "8.4.0.2")))
 (define build-deps '("rackunit-lib" "racket-doc" "scribble-lib" "math-lib" "compatibility-lib"))


### PR DESCRIPTION
As @sorawee pointed out on Discord, a recent commit on Racket https://github.com/racket/racket/commit/b8dbadec94ebc4ed30521b64f993398bf1399754 seems to break the current implementation of `~for/common` in generic-bind: https://plt.cs.northwestern.edu/pkg-build/server/built/fail/generic-bind.txt

Update: After https://github.com/racket/racket/commit/d44df889d362eec675d8535f931a86965b054835, I think there is a hope that it won't be broken anymore. But I still believe the `#:do` strategy has the advantage of implementing new `for` variants such as `for/foldr` and `for/hashalw` much more easily, with no `foldr` or `hashalw`-specific code other than the name.

Since Racket v8.4.0.2, `for` loops have included a `#:do` keyword that can be used to insert generic-bind definers much more easily than the current strategy of expanding the for clause and restructuring the result of expansion.

Closes #20 by adding `~for/foldr` and `~for*/foldr`.

Tasks:
 - [x] `~for/first`
 - [x] `~for/vector`
 - [x] `~for/foldr`
 - [x] `~for/hashalw`
 - [x] tests for `~for/foldr`
 - [x] tests for `~for/hashalw`
 - [x] tests for `~for` generic binds on scoping and for-nesting
 - [x] docs for `~for/foldr`
 - [x] docs for `~for/hashalw`
 - [x] branch and version exceptions for Racket versions 8.4 and earlier